### PR TITLE
Move PointData template class to its own files and use extern templates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 
@@ -18,6 +18,8 @@ file( GLOB header_list Src_CC_wrap/*.h )
 file( GLOB source_list Src_CC_wrap/*.cpp )
 
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} )
+
+target_include_directories( ${PROJECT_NAME} PRIVATE Src )
 
 # Add preprocessor definitions
 target_compile_definitions( ${PROJECT_NAME} PRIVATE _CRT_SECURE_NO_DEPRECATE _CRT_SECURE_NO_WARNINGS NOMINMAX )

--- a/Src_CC_wrap/PointData.cpp
+++ b/Src_CC_wrap/PointData.cpp
@@ -1,0 +1,21 @@
+//##########################################################################
+//#                                                                        #
+//#               CLOUDCOMPARE WRAPPER: PoissonReconLib                    #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 or later of the License.      #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#               COPYRIGHT: CloudCompare Project                          #
+//#                                                                        #
+//##########################################################################
+
+#include "PointData.h"
+
+template class PointData<float>;
+template class PointData<double>;

--- a/Src_CC_wrap/PointData.h
+++ b/Src_CC_wrap/PointData.h
@@ -1,0 +1,74 @@
+//##########################################################################
+//#                                                                        #
+//#               CLOUDCOMPARE WRAPPER: PoissonReconLib                    #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 or later of the License.      #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#               COPYRIGHT: Daniel Girardeau-Montaut                      #
+//#                                                                        #
+//##########################################################################
+
+#ifndef POINTDATA_H
+#define POINTDATA_H
+
+template <typename Real>
+class PointData {
+public:
+	PointData() : normal{ 0, 0, 0 }, color{ 0, 0, 0 } {}
+	PointData(const Real _normal[3], const Real _color[3], Real scale = 1.0)
+	{
+		normal[0] = scale * _normal[0];
+		normal[1] = scale * _normal[1];
+		normal[2] = scale * _normal[2];
+		color[0] = scale * _color[0];
+		color[1] = scale * _color[1];
+		color[2] = scale * _color[2];
+	}
+
+	PointData operator * (Real s) const
+	{
+		return PointData(normal, color, s);
+	}
+
+	PointData operator / (Real s) const
+	{
+		return PointData(normal, color, 1 / s);
+	}
+
+	PointData& operator += (const PointData& d)
+	{
+		normal[0] += d.normal[0];
+		normal[1] += d.normal[1];
+		normal[2] += d.normal[2];
+		color[0] += d.color[0];
+		color[1] += d.color[1];
+		color[2] += d.color[2];
+		return *this;
+	}
+	PointData& operator *= (Real s)
+	{
+		normal[0] *= s;
+		normal[1] *= s;
+		normal[2] *= s;
+		color[0] *= s;
+		color[1] *= s;
+		color[2] *= s;
+		return *this;
+	}
+
+public:
+	Real normal[3];
+	Real color[3];
+};
+
+extern template class PointData<float>;
+extern template class PointData<double>;
+
+#endif // POINTDATA_H


### PR DESCRIPTION
Also:
- increase cmake min version to 3.0
- add include directory in cmake to avoid relative paths in includes
- de-template-ize simple normal computation and move to anonymous namespace

Note: Unfortunately I cannot move other templates out because of the all-or-nothing structure of the Poisson files